### PR TITLE
Add support for PHP 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           command: |
             echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
             source $BASH_ENV
-            gem install bundler
-      - run: bundle install
-      - run: bundle exec rake spec
+            sudo gem update --system --no-user-install
+            sudo gem install bundler
+      - run: sudo bundle install
+      - run: sudo bundle exec rake spec

--- a/lib/puppet/parser/functions/ensure_php_packages.rb
+++ b/lib/puppet/parser/functions/ensure_php_packages.rb
@@ -32,6 +32,9 @@ EOS
         if version.to_s >= "7.2" && package === "mcrypt"
           next
         end
+        if version.to_s >= "8.0" && (package === "xmlrpc" || package === "json")
+          next
+        end
         function_ensure_resource(["package", "php#{version.to_s}-#{package}", defaults])
       end
     end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 class ss_php(
-  Optional[Pattern[/^[57].[0-9]/]] $php_version = $::ss_php::params::php_version,
+  Optional[Pattern[/^[578].[0-9]/]] $php_version = $::ss_php::params::php_version,
   $cli = $::ss_php::params::cli,
   $dev = $::ss_php::params::dev,
   $apcu = $::ss_php::params::apcu,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -5,6 +5,8 @@ define ss_php::package(
   $php_version_float = Numeric($php_version)
   if $php_version_float >= 7.2 and $name == 'mcrypt' {
     notice('mcrypt is deprecated and unavailable for PHP >= 7.2. Skipping install')
+  } elsif $php_version_float >= 8.0 and ($name == 'json' or $name == 'xmlrpc') {
+    notice("${name} is not available as a standard package for PHP >= 8. Skipping install")
   } else {
     package { "php${php_version}-${name}":
       ensure  => $ensure,

--- a/spec/functions/ensure_php_packages_spec.rb
+++ b/spec/functions/ensure_php_packages_spec.rb
@@ -15,4 +15,21 @@ describe "ensure_php_packages" do
       expect(catalogue).to contain_package("php5.6-gd").with_ensure("absent")
       expect(catalogue).to contain_package("php7.1-gd").with_ensure("absent")
     end
+    it "skips dependencies that should not be installed" do
+      is_expected.to run.with_params(["mcrypt", "json", "xmlrpc"], ["7.1", "7.4", "8.0"])
+      # Mcrypt not provided in PHP 7.2+
+      expect(catalogue).to contain_package("php7.1-mcrypt").with_ensure("present")
+      expect(catalogue).to_not contain_package("php7.4-mcrypt")
+      expect(catalogue).to_not contain_package("php8.0-mcrypt")
+
+      # JSON not provided as a package in PHP 8+
+      expect(catalogue).to contain_package("php7.1-json").with_ensure("present")
+      expect(catalogue).to contain_package("php7.4-json").with_ensure("present")
+      expect(catalogue).to_not contain_package("php8.0-json")
+
+      # PECL extension not provided as a package in PHP 8+
+      expect(catalogue).to contain_package("php7.1-xmlrpc").with_ensure("present")
+      expect(catalogue).to contain_package("php7.4-xmlrpc").with_ensure("present")
+      expect(catalogue).to_not contain_package("php8.0-xmlrpc")
+    end
 end


### PR DESCRIPTION
- Allows PHP 8 to be installed
- Skips the installation of `json` and `xmlrpc` as they are either now bundled into core, or no longer available as standard packages.
- Fixes unit tests