### PR TITLE
Remove custom apcu, imagick logic as versioned packages now exist in sury

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,13 +1,7 @@
 class ss_php(
   $php_version = $::ss_php::params::php_version,
   $dev = $::ss_php::params::dev,
-  $apcu = $::ss_php::params::apcu,
-  $imagick = $::ss_php::params::imagick,
 ) inherits ::ss_php::params {
-  if $php_version != undef {
-    validate_re($php_version, '^[57].[0-9]')
-  }
-
   $globals_php_version = pick($php_version, $::ss_php::params::php_version)
   $globals_cli_inifile = "/etc/php/${globals_php_version}/cli/php.ini"
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,26 +24,4 @@ class ss_php::install inherits ::ss_php {
       ensure => absent,
     }
   }
-
-  if $apcu {
-    package { 'php-apcu':
-      ensure  => present,
-      require => Ss_php::Package['cli'],
-    }
-  } else {
-    package { 'php-apcu':
-      ensure => absent,
-    }
-  }
-
-  if $imagick {
-    package { 'php-imagick':
-      ensure  => present,
-      require => Ss_php::Package['cli'],
-    }
-  } else {
-    package { 'php-imagick':
-      ensure => absent,
-    }
-  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,5 @@ class ss_php::params(
   $php_version = '7.1',
   $cli_inifile = '/etc/php/7.1/cli/php.ini',
   $dev = true,
-  $apcu = true,
-  $imagick = true,
 ) {
 }


### PR DESCRIPTION
Sury now provides Apcu and Imagick packages via versioned prefixes. Remove custom logic for these packages in favor of using `ss_php::package` for installing instead.

E.g. 
Previously `php-apcu`, `php-imagick`
Updated `php7.2-apcu`, `php7.2-imagick`.

These versioned packages exist for PHP 5.6 -> 8.0 currently (all installed versions)
