### PR TITLE
Sury upstream updates - Merge to `puppet-upgrade`

### DIFF
--- a/lib/puppet/parser/functions/ensure_php_packages.rb
+++ b/lib/puppet/parser/functions/ensure_php_packages.rb
@@ -32,7 +32,10 @@ EOS
         if version.to_s >= "7.2" && package === "mcrypt"
           next
         end
-        if version.to_s >= "8.0" && (package === "xmlrpc" || package === "json")
+        if version.to_s >= "8.0" && (package === "xmlrpc" || package === "json" || package === 'apcu-bc')
+          next
+        end
+        if version.to_s <= "5.6" && package === "apcu-bc"
           next
         end
         function_ensure_resource(["package", "php#{version.to_s}-#{package}", defaults])

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,8 +2,6 @@ class ss_php(
   Optional[Pattern[/^[578].[0-9]/]] $php_version = $::ss_php::params::php_version,
   $cli = $::ss_php::params::cli,
   $dev = $::ss_php::params::dev,
-  $apcu = $::ss_php::params::apcu,
-  $imagick = $::ss_php::params::imagick,
 ) inherits ::ss_php::params {
   $globals_php_version = pick($php_version, $::ss_php::params::php_version)
   $globals_cli_inifile = "/etc/php/${globals_php_version}/cli/php.ini"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,12 +28,14 @@ class ss_php::install inherits ::ss_php {
   }
 
   if $::ss_php::apcu {
-    package { 'php-apcu':
-      ensure  => present,
+    package {
+      'php-apcu': ensure  => present;
+      'php-apcu-bc': ensure  => present;
     }
   } else {
-    package { 'php-apcu':
-      ensure => absent,
+    package {
+      'php-apcu': ensure => absent;
+      'php-apcu-bc': ensure  => absent;
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,26 +26,4 @@ class ss_php::install inherits ::ss_php {
       ensure => absent,
     }
   }
-
-  if $::ss_php::apcu {
-    package {
-      'php-apcu': ensure  => present;
-      'php-apcu-bc': ensure  => present;
-    }
-  } else {
-    package {
-      'php-apcu': ensure => absent;
-      'php-apcu-bc': ensure  => absent;
-    }
-  }
-
-  if $::ss_php::imagick {
-    package { 'php-imagick':
-      ensure  => present,
-    }
-  } else {
-    package { 'php-imagick':
-      ensure => absent,
-    }
-  }
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -7,6 +7,8 @@ define ss_php::package(
     notice('mcrypt is deprecated and unavailable for PHP >= 7.2. Skipping install')
   } elsif $php_version_float >= 8.0 and ($name == 'json' or $name == 'xmlrpc' or $name == 'apcu-bc') {
     notice("${name} is not available as a standard package for PHP >= 8. Skipping install")
+  } elsif $php_version_float <= 5.6 and $name == 'apcu-bc' {
+    notice("${name} is not available as a standard package for PHP <= 5.6. Skipping install")
   } else {
     package { "php${php_version}-${name}":
       ensure  => $ensure

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -5,7 +5,7 @@ define ss_php::package(
   $php_version_float = Numeric($php_version)
   if $php_version_float >= 7.2 and $name == 'mcrypt' {
     notice('mcrypt is deprecated and unavailable for PHP >= 7.2. Skipping install')
-  } elsif $php_version_float >= 8.0 and ($name == 'json' or $name == 'xmlrpc') {
+  } elsif $php_version_float >= 8.0 and ($name == 'json' or $name == 'xmlrpc' or $name == 'apcu-bc') {
     notice("${name} is not available as a standard package for PHP >= 8. Skipping install")
   } else {
     package { "php${php_version}-${name}":

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -9,8 +9,7 @@ define ss_php::package(
     notice("${name} is not available as a standard package for PHP >= 8. Skipping install")
   } else {
     package { "php${php_version}-${name}":
-      ensure  => $ensure,
-      require => Class['::apt::update']
+      ensure  => $ensure
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,5 @@ class ss_php::params(
   $cli_inifile = '/etc/php/7.1/cli/php.ini',
   $cli = true,
   $dev = true,
-  $apcu = true,
-  $imagick = true,
 ) {
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -15,6 +15,7 @@ class ss_php::repo {
       location    => 'https://packages.sury.org/php/',
       release     => $::lsbdistcodename,
       repos       => 'main',
+      notify      => Exec['ss_php_repo_force_update'],
       include     => {
         src => false
       },
@@ -26,4 +27,12 @@ class ss_php::repo {
   } else {
     fail('Unsupported operating system for PHP')
   }
+
+  exec { 'ss_php_repo_force_update':
+      command     => "/bin/echo 'Apt update after adding sury repo'",
+      refreshonly => true,
+      logoutput   => true,
+      subscribe   => Exec['apt_update'],
+  }
+  
 }


### PR DESCRIPTION
Changes to support upstream APCU and Imagick updates to package names.

 - Apcu packages are now available via prefixed packages (E.g. php7.2-apcu, php7.2-apcu-bc).
 - Imagick packages are now available via prefixed packages (E.g. php7.2-imagick).
 - Apcu-BC package not available for PHP 8.0, extended validation to skip apcu-bc package for PHP 8.0

Includes:
 - #17 (Repo APT Update)