### PR TITLE
Loose dependencies so that it's easier to librarian-puppet update.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,25 +9,25 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.6.0 < 7.0.0"
+      "version_requirement": ">=4.6.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.1.0 < 7.0.0"
+      "version_requirement": ">=2.1.0"
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">=1.6.0 < 4.0.0"
+      "version_requirement": ">=1.6.0"
     },
     {
       "name": "puppet/alternatives",
-      "version_requirement": ">=1.0.1 < 3.0.0"
+      "version_requirement": ">=1.0.1"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.0.0 < 7.0.0"
+      "version_requirement": ">=3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This module isn't really affected by a lot of major upstream updates, so
pinning majors is overly cautions in this ecosystem.