### PR TITLE
fixing opcache issue with php 8.5 install

### DIFF
--- a/lib/puppet/parser/functions/ensure_php_packages.rb
+++ b/lib/puppet/parser/functions/ensure_php_packages.rb
@@ -38,6 +38,9 @@ EOS
         if version.to_s <= "5.6" && package === "apcu-bc"
           next
         end
+        if version.to_s >= "8.5" && package === "opcache"
+          next
+        end
         function_ensure_resource(["package", "php#{version.to_s}-#{package}", defaults])
       end
     end

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -9,6 +9,8 @@ define ss_php::package(
     notice("${name} is not available as a standard package for PHP >= 8. Skipping install")
   } elsif $php_version_float <= 5.6 and $name == 'apcu-bc' {
     notice("${name} is not available as a standard package for PHP <= 5.6. Skipping install")
+  } elsif $php_version_float >= 8.5 and $name == 'opcache' {
+    notice("${name} is not available as a standard package for PHP >= 8.5 Skipping install")
   } else {
     package { "php${php_version}-${name}":
       ensure => $ensure,

--- a/spec/functions/ensure_php_packages_spec.rb
+++ b/spec/functions/ensure_php_packages_spec.rb
@@ -16,7 +16,7 @@ describe "ensure_php_packages" do
       expect(catalogue).to contain_package("php7.1-gd").with_ensure("absent")
     end
     it "skips dependencies that should not be installed" do
-      is_expected.to run.with_params(["mcrypt", "json", "xmlrpc"], ["7.1", "7.4", "8.0"])
+      is_expected.to run.with_params(["mcrypt", "json", "xmlrpc", "opcache"], ["7.1", "7.4", "8.0", "8.5"])
       # Mcrypt not provided in PHP 7.2+
       expect(catalogue).to contain_package("php7.1-mcrypt").with_ensure("present")
       expect(catalogue).to_not contain_package("php7.4-mcrypt")
@@ -31,5 +31,10 @@ describe "ensure_php_packages" do
       expect(catalogue).to contain_package("php7.1-xmlrpc").with_ensure("present")
       expect(catalogue).to contain_package("php7.4-xmlrpc").with_ensure("present")
       expect(catalogue).to_not contain_package("php8.0-xmlrpc")
+
+      # Opcache not provided in PHP 8.5+
+      expect(catalogue).to contain_package("php7.1-opcache").with_ensure("present")
+      expect(catalogue).to contain_package("php8.0-opcache").with_ensure("present")
+      expect(catalogue).to_not contain_package("php8.5-opcache")
     end
 end


### PR DESCRIPTION
opcache is now included by default, so we need to not specify the non existent package